### PR TITLE
Add `rustc_pattern_analysis` to list of auto published crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for automatically publishing the below crates every Tuesday.
 
 - [ra-ap_rustc_lexer][ra-ap_rustc_lexer-crate] [![ra-ap_rustc_lexer version][ra-ap_rustc_lexer-version-badge]][ra-ap_rustc_lexer-crate]
 - [ra-ap_rustc_serialize][ra-ap_rustc_serialize-crate] [![ra-ap_rustc_serialize version][ra-ap_rustc_serialize-version-badge]][ra-ap_rustc_serialize-crate]
-- [ra-ap_rustc_lexer][ra-ap_rustc_index-crate] [![ra-ap_rustc_index version][ra-ap_rustc_index-version-badge]][ra-ap_rustc_index-crate]
+- [ra-ap_rustc_index][ra-ap_rustc_index-crate] [![ra-ap_rustc_index version][ra-ap_rustc_index-version-badge]][ra-ap_rustc_index-crate]
 - [ra-ap_rustc_macros][ra-ap_rustc_macros-crate] [![ra-ap_rustc_macros version][ra-ap_rustc_macros-version-badge]][ra-ap_rustc_macros-crate]
 - [ra-ap_rustc_parse_format][ra-ap_rustc_parse_format-crate] [![ra-ap_rustc_parse_format version][ra-ap_rustc_parse_format-version-badge]][ra-ap_rustc_parse_format-crate]
 - [ra-ap_rustc_abi][ra-ap_rustc_abi-crate] [![ra-ap_rustc_abi version][ra-ap_rustc_abi-version-badge]][ra-ap_rustc_abi-crate]

--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 Repository for automatically publishing the below crates every Tuesday.
 
-- [ra-ap_rustc_lexer][ra-ap_rustc_lexer-crate] [![ra-ap_rustc_lexer version][ra-ap_rustc_lexer-version-badge]][ra-ap_rustc_lexer-crate]
-- [ra-ap_rustc_serialize][ra-ap_rustc_serialize-crate] [![ra-ap_rustc_serialize version][ra-ap_rustc_serialize-version-badge]][ra-ap_rustc_serialize-crate]
+- [ra-ap_rustc_abi][ra-ap_rustc_abi-crate] [![ra-ap_rustc_abi version][ra-ap_rustc_abi-version-badge]][ra-ap_rustc_abi-crate]
 - [ra-ap_rustc_index][ra-ap_rustc_index-crate] [![ra-ap_rustc_index version][ra-ap_rustc_index-version-badge]][ra-ap_rustc_index-crate]
+- [ra-ap_rustc_lexer][ra-ap_rustc_lexer-crate] [![ra-ap_rustc_lexer version][ra-ap_rustc_lexer-version-badge]][ra-ap_rustc_lexer-crate]
 - [ra-ap_rustc_macros][ra-ap_rustc_macros-crate] [![ra-ap_rustc_macros version][ra-ap_rustc_macros-version-badge]][ra-ap_rustc_macros-crate]
 - [ra-ap_rustc_parse_format][ra-ap_rustc_parse_format-crate] [![ra-ap_rustc_parse_format version][ra-ap_rustc_parse_format-version-badge]][ra-ap_rustc_parse_format-crate]
-- [ra-ap_rustc_abi][ra-ap_rustc_abi-crate] [![ra-ap_rustc_abi version][ra-ap_rustc_abi-version-badge]][ra-ap_rustc_abi-crate]
 - [ra-ap_rustc_pattern_analysis][ra-ap_rustc_pattern_analysis-crate] [![ra-ap_rustc_pattern_analysis version][ra-ap_rustc_pattern_analysis-version-badge]][ra-ap_rustc_pattern_analysis-crate]
+- [ra-ap_rustc_serialize][ra-ap_rustc_serialize-crate] [![ra-ap_rustc_serialize version][ra-ap_rustc_serialize-version-badge]][ra-ap_rustc_serialize-crate]
 
-[ra-ap_rustc_lexer-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_lexer?style=flat-square
-[ra-ap_rustc_macros-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_macros?style=flat-square
-[ra-ap_rustc_serialize-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_serialize?style=flat-square
-[ra-ap_rustc_index-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_index?style=flat-square
-[ra-ap_rustc_parse_format-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_parse_format?style=flat-square
-[ra-ap_rustc_abi-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_abi?style=flat-square
-[ra-ap_rustc_pattern_analysis-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_pattern_analysis?style=flat-square
-[ra-ap_rustc_lexer-crate]: https://crates.io/crates/ra-ap_rustc_lexer
-[ra-ap_rustc_macros-crate]: https://crates.io/crates/ra-ap_rustc_macros
-[ra-ap_rustc_serialize-crate]: https://crates.io/crates/ra-ap_rustc_serialize
-[ra-ap_rustc_index-crate]: https://crates.io/crates/ra-ap_rustc_index
-[ra-ap_rustc_parse_format-crate]: https://crates.io/crates/ra-ap_rustc_parse_format
 [ra-ap_rustc_abi-crate]: https://crates.io/crates/ra-ap_rustc_abi
+[ra-ap_rustc_abi-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_abi?style=flat-square
+[ra-ap_rustc_index-crate]: https://crates.io/crates/ra-ap_rustc_index
+[ra-ap_rustc_index-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_index?style=flat-square
+[ra-ap_rustc_lexer-crate]: https://crates.io/crates/ra-ap_rustc_lexer
+[ra-ap_rustc_lexer-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_lexer?style=flat-square
+[ra-ap_rustc_macros-crate]: https://crates.io/crates/ra-ap_rustc_macros
+[ra-ap_rustc_macros-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_macros?style=flat-square
+[ra-ap_rustc_parse_format-crate]: https://crates.io/crates/ra-ap_rustc_parse_format
+[ra-ap_rustc_parse_format-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_parse_format?style=flat-square
 [ra-ap_rustc_pattern_analysis-crate]: https://crates.io/crates/ra-ap_rustc_pattern_analysis
+[ra-ap_rustc_pattern_analysis-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_pattern_analysis?style=flat-square
+[ra-ap_rustc_serialize-crate]: https://crates.io/crates/ra-ap_rustc_serialize
+[ra-ap_rustc_serialize-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_serialize?style=flat-square

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Repository for automatically publishing the below crates every Tuesday.
 - [ra-ap_rustc_macros][ra-ap_rustc_macros-crate] [![ra-ap_rustc_macros version][ra-ap_rustc_macros-version-badge]][ra-ap_rustc_macros-crate]
 - [ra-ap_rustc_parse_format][ra-ap_rustc_parse_format-crate] [![ra-ap_rustc_parse_format version][ra-ap_rustc_parse_format-version-badge]][ra-ap_rustc_parse_format-crate]
 - [ra-ap_rustc_abi][ra-ap_rustc_abi-crate] [![ra-ap_rustc_abi version][ra-ap_rustc_abi-version-badge]][ra-ap_rustc_abi-crate]
+- [ra-ap_rustc_pattern_analysis][ra-ap_rustc_pattern_analysis-crate] [![ra-ap_rustc_pattern_analysis version][ra-ap_rustc_pattern_analysis-version-badge]][ra-ap_rustc_pattern_analysis-crate]
 
 [ra-ap_rustc_lexer-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_lexer?style=flat-square
 [ra-ap_rustc_macros-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_macros?style=flat-square
@@ -15,9 +16,11 @@ Repository for automatically publishing the below crates every Tuesday.
 [ra-ap_rustc_index-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_index?style=flat-square
 [ra-ap_rustc_parse_format-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_parse_format?style=flat-square
 [ra-ap_rustc_abi-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_abi?style=flat-square
+[ra-ap_rustc_pattern_analysis-version-badge]: https://img.shields.io/crates/v/ra-ap_rustc_pattern_analysis?style=flat-square
 [ra-ap_rustc_lexer-crate]: https://crates.io/crates/ra-ap_rustc_lexer
 [ra-ap_rustc_macros-crate]: https://crates.io/crates/ra-ap_rustc_macros
 [ra-ap_rustc_serialize-crate]: https://crates.io/crates/ra-ap_rustc_serialize
 [ra-ap_rustc_index-crate]: https://crates.io/crates/ra-ap_rustc_index
 [ra-ap_rustc_parse_format-crate]: https://crates.io/crates/ra-ap_rustc_parse_format
 [ra-ap_rustc_abi-crate]: https://crates.io/crates/ra-ap_rustc_abi
+[ra-ap_rustc_pattern_analysis-crate]: https://crates.io/crates/ra-ap_rustc_pattern_analysis

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ fn main() {
             name: "rustc_abi".to_owned(),
             dir: "compiler/rustc_abi".to_owned(),
         },
+        RustcApCrate {
+            name: "rustc_pattern_analysis".to_owned(),
+            dir: "compiler/rustc_pattern_analysis".to_owned(),
+        },
     ];
 
     println!("learning about the dependency graph");

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,16 +30,16 @@ fn main() {
 
     let target_crates = vec![
         RustcApCrate {
+            name: "rustc_abi".to_owned(),
+            dir: "compiler/rustc_abi".to_owned(),
+        },
+        RustcApCrate {
             name: "rustc_lexer".to_owned(),
             dir: "compiler/rustc_lexer".to_owned(),
         },
         RustcApCrate {
             name: "rustc_parse_format".to_owned(),
             dir: "compiler/rustc_parse_format".to_owned(),
-        },
-        RustcApCrate {
-            name: "rustc_abi".to_owned(),
-            dir: "compiler/rustc_abi".to_owned(),
         },
         RustcApCrate {
             name: "rustc_pattern_analysis".to_owned(),


### PR DESCRIPTION
That crate contains the match exhaustiveness algorithm, which has been librarified for use in rust-analyzer. It compiles on stable with `--no-default-features --feature stable`. (and after https://github.com/rust-lang/rust/pull/119581 it will compile on stable with just `--no-default-features`).

(I took the liberty to sort things in the last commit :angel:)