### PR TITLE
Revert "Disable rustc_pattern_analysis publish temporarly"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,11 +44,11 @@ fn main() {
             dir: "compiler/rustc_parse_format".to_owned(),
             in_tree_feature_name: "nightly".to_owned(),
         },
-        // RustcApCrate {
-        //     name: "rustc_pattern_analysis".to_owned(),
-        //     dir: "compiler/rustc_pattern_analysis".to_owned(),
-        //     in_tree_feature_name: "rustc".to_owned(),
-        // },
+        RustcApCrate {
+            name: "rustc_pattern_analysis".to_owned(),
+            dir: "compiler/rustc_pattern_analysis".to_owned(),
+            in_tree_feature_name: "rustc".to_owned(),
+        },
     ];
 
     eprintln!("learning about the dependency graph");


### PR DESCRIPTION
This reverts commit f72fda718f614c06f723055496fd7b5b108e2193.